### PR TITLE
Create sqs-azsb-csnf-splunk-sentinel.yaml

### DIFF
--- a/birthday-cake/manifests/sqs-azsb-csnf-splunk-sentinel.yaml
+++ b/birthday-cake/manifests/sqs-azsb-csnf-splunk-sentinel.yaml
@@ -1,0 +1,172 @@
+
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: brkr
+
+---
+
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: tmdbgr-brkr
+spec:
+  broker: brkr
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: sockeye
+
+---
+
+# The event source for our Aquasec events
+apiVersion: sources.triggermesh.io/v1alpha1
+kind: AWSSQSSource
+metadata:
+  name: sample
+spec:
+  arn: <SQSARN>
+
+  auth:
+    credentials:
+      accessKeyID:
+        valueFromSecret:
+          name: aws
+          key: access_key_id
+      secretAccessKey:
+        valueFromSecret:
+          name: aws
+          key: secret_access_key
+  sink:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: hello-csnf
+
+---
+
+# The event source for our guardduty events
+apiVersion: sources.triggermesh.io/v1alpha1
+kind: AzureServiceBusQueueSource
+metadata:
+  name: sample
+spec:
+  queueID: <QUEUE_ID>
+  auth:
+    sasToken:
+      connectionString:
+        value: <CONNECTION_STRING>
+  sink:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: hello-csnf
+
+---
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: hello-csnf
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/triggermesh/demoservice:latest
+          env:
+          - name: K_SINK
+            value: http://broker-ingress.knative-eventing.svc.cluster.local/default/brkr
+
+
+---
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: hello-sentinel
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/triggermesh/azuresentineltarget:latest
+          env:
+          - name: AZURE_SUBSCRIPTION_ID
+            value: <AZURE_SUBSCRIPTION_ID>
+          - name: AZURE_RESOURCE_GROUP
+            value: <AZURE_RESOURCE_GROUP>
+          - name: AZURE_WORKSPACE
+            value: <AZURE_WORKSPACE>
+          - name: AZURE_CLIENT_SECRET
+            value: <AZURE_CLIENT_SECRET>
+          - name: AZURE_CLIENT_ID
+            value: <AZURE_CLIENT_ID>
+          - name: AZURE_TENANT_ID
+            value: <AZURE_TENANT_ID>
+
+---
+
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: hello-sentinel-as
+spec:
+  broker: brkr
+  filter:
+    attributes:
+      type: io.triggermesh.csnf.event.aquasec
+  subscriber:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: hello-sentinel
+
+
+---
+
+apiVersion: targets.triggermesh.io/v1alpha1
+kind: SplunkTarget
+metadata:
+    name: splunk-distribution
+spec:
+    endpoint: <HEC_ENDPOINT>
+    skipTLSVerify: true
+    token:
+        valueFromSecret:
+            key: token
+            name: splunk-hec
+
+---
+
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: hello-splunk
+spec:
+  broker: brkr
+  filter:
+    attributes:
+      type: io.triggermesh.csnf.event.aquasec
+  subscriber:
+    ref:
+      apiVersion: targets.triggermesh.io/v1alpha1
+      kind: SplunkTarget
+      name: splunk-distribution
+
+---
+
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: hello-splunk-gd
+spec:
+  broker: brkr
+  filter:
+    attributes:
+      type: io.triggermesh.csnf.event.guardduty
+  subscriber:
+    ref:
+      apiVersion: targets.triggermesh.io/v1alpha1
+      kind: SplunkTarget
+      name: splunk-distribution
+


### PR DESCRIPTION
Creates an example manifest for SQS & Azure Service Bus sources feeding the CSNF service and sinking events to Azure Sentinel and Splunk